### PR TITLE
Fix error with gamertags that contain spaces

### DIFF
--- a/src/httpWrapper.js
+++ b/src/httpWrapper.js
@@ -14,7 +14,7 @@ function httpWrapper(API_KEY){
 httpWrapper.prototype.queryAPI = function(path) {
   return new Promise((resolve, reject) => {
     let _options = options;
-    _options.path = path;
+    _options.path = encodeURI(path);
     let responseText = '';
     let request = https.request(_options, (response) => {
       response.on('data', (data) => {


### PR DESCRIPTION
I had an issue when making a request with my gamertag `MAX1MUM D3ATH`. It appeared to be an issue with the url of the request containing a space. Using `encodeURI(path)` in `httpWrapper.js` resolves this by making sure the path is a valid URI format.